### PR TITLE
Closing #37

### DIFF
--- a/de.atb.typhondl.xtext.ui/templates/templates.xml
+++ b/de.atb.typhondl.xtext.ui/templates/templates.xml
@@ -9,6 +9,12 @@
 <template id="dbType_mysql" autoinsert="true" context="de.atb.typhondl.xtext.TyphonDL.DBType" deleted="false" description="Default template for dbtype MySQL using the latest image from Docker Hub" enabled="true" name="MySQLType">dbtype MySQL {
     default image = mysql:latest;
 }</template>
+<template id="dbType_cassandra" autoinsert="true" context="de.atb.typhondl.xtext.TyphonDL.DBType" deleted="false" description="Default template for dbtype Cassandra using the latest image from Docker Hub" enabled="true" name="Cassandra">dbtype Cassandra {
+    default image = cassandra:latest;
+}</template>
+<template id="dbType_neo4j" autoinsert="true" context="de.atb.typhondl.xtext.TyphonDL.DBType" deleted="false" description="Default template for dbtype Neo4j using the latest image from Docker Hub" enabled="true" name="Neo4j">dbtype Neo4j {
+    default image = neo4j:latest;
+}</template>
 <template id="db_mariadb" autoinsert="true" context="de.atb.typhondl.xtext.TyphonDL.DB" deleted="false" description="default minimal template for MariaDB" enabled="true" name="MariaDB">database ${databaseName} : MariaDB {
     environment {
         MYSQL_ROOT_PASSWORD = ${password} ;
@@ -24,6 +30,13 @@
 <template id="db_mysql" autoinsert="true" context="de.atb.typhondl.xtext.TyphonDL.DB" deleted="false" description="default minimal template for MySQL" enabled="true" name="MySQL">database ${databaseName} : MySQL {
     environment {
         MYSQL_ROOT_PASSWORD = ${password} ;
+    }
+}</template>
+<template id="db_cassandra" autoinsert="true" context="de.atb.typhondl.xtext.TyphonDL.DB" deleted="false" description="default minimal template for Cassandra" enabled="true" name="Cassandra">database ${name} : Cassandra {
+}</template>
+<template id="db_neo4j" autoinsert="true" context="de.atb.typhondl.xtext.TyphonDL.DB" deleted="false" description="default minimal template for Neo4j" enabled="true" name="Neo4j">database ${name} : Neo4j {
+    environment {
+        NEO4J_AUTH = neo4j/${password};
     }
 }</template>
 </templates>


### PR DESCRIPTION
Basic templates for Cassandra and Neo4j are added.
For using the respective databases directly, access the container by
```
docker exec -it <container-name> sh
```
then for Cassandra: `cqlsh`
and for Neo4j: `cypher-shell -u neo4j -p <password>`