### PR TITLE
add default volumes

### DIFF
--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/creationWizard/CreationDatabasePage.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/creationWizard/CreationDatabasePage.java
@@ -81,12 +81,17 @@ public class CreationDatabasePage extends MyWizardPage {
         String containerName = ContainerService.createContainerName(db.getName());
         // the containerType get's created and added to the container in ModelCreator,
         // so that all containers have the same containerType instance
-        Container newContainer = ContainerService.create(containerName, null, db, containerName + ":" + getPort());
+        Container newContainer = ContainerService.create(containerName, null, db, containerName + ":" + getPort(),
+                getVolumeTarget(), chosenTechnology);
         return newContainer;
     }
 
     private String getPort() {
         return properties.getProperty(db.getType().getName().toLowerCase() + ".port");
+    }
+
+    private String getVolumeTarget() {
+        return properties.getProperty(db.getType().getName().toLowerCase() + ".volumeTarget");
     }
 
     @Override

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/creationWizard/ModelCreator.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/creationWizard/ModelCreator.java
@@ -50,6 +50,7 @@ import de.atb.typhondl.xtext.typhonDL.Import;
 import de.atb.typhondl.xtext.typhonDL.Platform;
 import de.atb.typhondl.xtext.typhonDL.PlatformType;
 import de.atb.typhondl.xtext.typhonDL.TyphonDLFactory;
+import de.atb.typhondl.xtext.typhonDL.Volume_Toplevel;
 import de.atb.typhondl.xtext.ui.activator.Activator;
 import de.atb.typhondl.xtext.ui.modelUtils.ModelService;
 import de.atb.typhondl.xtext.ui.properties.PropertiesService;
@@ -227,12 +228,24 @@ public class ModelCreator {
         application.setName("Polystore");
         cluster.getApplications().add(application);
 
+        Volume_Toplevel toplevelVolume = TyphonDLFactory.eINSTANCE.createVolume_Toplevel();
+
         for (DB db : result.keySet()) {
             Container container = result.get(db);
             if (!db.isExternal()) {
                 container.setType(containerType);
                 application.getContainers().add(container);
+                if (container.getVolumes() != null) {
+                    String volumeName = container.getVolumes().getDecls().get(0).getVolumeName();
+                    if (!volumeName.isEmpty()) {
+                        toplevelVolume.getNames().add(volumeName);
+                    }
+                }
             }
+        }
+
+        if (!toplevelVolume.getNames().isEmpty()) {
+            application.setVolumes(toplevelVolume);
         }
 
         /*

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/modelUtils/ContainerService.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/modelUtils/ContainerService.java
@@ -17,10 +17,13 @@ import de.atb.typhondl.xtext.typhonDL.Replication;
 import de.atb.typhondl.xtext.typhonDL.Services;
 import de.atb.typhondl.xtext.typhonDL.TyphonDLFactory;
 import de.atb.typhondl.xtext.typhonDL.URI;
+import de.atb.typhondl.xtext.typhonDL.Volumes;
+import de.atb.typhondl.xtext.ui.utilities.SupportedTechnologies;
 
 public class ContainerService {
 
-    public static Container create(String name, ContainerType containerType, Services deploys, String uri) {
+    public static Container create(String name, ContainerType containerType, Services deploys, String uri,
+            String volumeTarget, SupportedTechnologies chosenTechnology) {
         Container container = TyphonDLFactory.eINSTANCE.createContainer();
         container.setName(name);
         container.setType(containerType);
@@ -33,6 +36,11 @@ public class ContainerService {
             URI uriObject = TyphonDLFactory.eINSTANCE.createURI();
             uriObject.setValue(uri);
             container.setUri(uriObject);
+        }
+        if (volumeTarget != null) {
+            Volumes volumes = VolumesService.create(new String[] { volumeTarget },
+                    VolumesService.getDefaultVolumesType(chosenTechnology), name + "volume");
+            container.setVolumes(volumes);
         }
         return container;
     }
@@ -99,6 +107,14 @@ public class ContainerService {
             }
         }
         return dependencyList;
+    }
+
+    public static Container create(String name, ContainerType containerType, Services deploys, String uri) {
+        return create(name, containerType, deploys, uri, null, null);
+    }
+
+    public static Container create(String name, ContainerType containerType, Services deploys) {
+        return create(name, containerType, deploys, null, null, null);
     }
 
 }

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/modelUtils/VolumesService.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/modelUtils/VolumesService.java
@@ -27,8 +27,7 @@ public class VolumesService {
     }
 
     private static ValueArray createPathArray(String[] volumePath) {
-        ValueArray volumePathArray;
-        volumePathArray = TyphonDLFactory.eINSTANCE.createValueArray();
+        ValueArray volumePathArray = TyphonDLFactory.eINSTANCE.createValueArray();
         volumePathArray.setValue(volumePath[0]);
         for (int i = 1; i < volumePath.length; i++) {
             volumePathArray.getValues().add(volumePath[i]);
@@ -82,7 +81,7 @@ public class VolumesService {
         return "";
     }
 
-    public static Volumes create(String[] path, String type, String name, SupportedTechnologies chosenTechnology) {
+    public static Volumes create(String[] path, String type, String name) {
         Volumes volumes = TyphonDLFactory.eINSTANCE.createVolumes();
 //        if (type == null) {
 //            type = getDefaultVolumesType(chosenTechnology);

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/polystore.properties
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/polystore.properties
@@ -137,6 +137,11 @@ cassandra.port = 9042
 mariadbgalera.port = 3306
 mongosharded.port = 27017
 
+mariadb.volumeTarget = /var/lib/mysql
+mongo.volumeTarget = /data/db
+neo4j.volumeTarget = /data
+cassandra.volumeTarget = /var/lib/cassandra
+
 #mariadb.replication.dockercompose = replicaset
 mongo.replication.dockercompose = replicaset
 #mariadb.replication.kubernetes = replicaset

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/refactoring/ClusterTypeRefactor.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/refactoring/ClusterTypeRefactor.java
@@ -3,6 +3,7 @@ package de.atb.typhondl.xtext.ui.refactoring;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.Properties;
 
 import org.eclipse.emf.ecore.EObject;
@@ -10,12 +11,15 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 
 import de.atb.typhondl.xtext.typhonDL.ClusterType;
 import de.atb.typhondl.xtext.typhonDL.DeploymentModel;
+import de.atb.typhondl.xtext.typhonDL.Volume_Properties;
 import de.atb.typhondl.xtext.ui.modelUtils.ModelService;
+import de.atb.typhondl.xtext.ui.modelUtils.VolumesService;
 import de.atb.typhondl.xtext.ui.properties.PropertiesService;
 import de.atb.typhondl.xtext.ui.utilities.PropertiesLoader;
 import de.atb.typhondl.xtext.ui.utilities.SavingOptions;
@@ -56,6 +60,7 @@ public class ClusterTypeRefactor {
                     }
                 }
                 clusterType.setName(newClusterType.getName());
+                changeVolumeTypes(model, clusterType);
                 try {
                     resource.save(SavingOptions.getTDLoptions());
                 } catch (IOException e) {
@@ -71,6 +76,17 @@ public class ClusterTypeRefactor {
 
         }
 
+    }
+
+    private static void changeVolumeTypes(DeploymentModel model, ClusterType clusterType) {
+        final List<Volume_Properties> allVolumeProperties = EcoreUtil2.getAllContentsOfType(model,
+                Volume_Properties.class);
+        for (Volume_Properties volume_Properties : allVolumeProperties) {
+            if (volume_Properties.getVolumeType() != null) {
+                volume_Properties.setVolumeType(
+                        VolumesService.getDefaultVolumesType(ModelService.getSupportedTechnology(clusterType)));
+            }
+        }
     }
 
     private static boolean shouldChangeAnalytics(Shell shell, Properties properties) {

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/scriptGeneration/AnalyticsService.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/scriptGeneration/AnalyticsService.java
@@ -91,7 +91,7 @@ public class AnalyticsService {
                         SoftwareService.createEnvironment(new String[] { "JOB_MANAGER_RPC_ADDRESS", "jobmanager" }));
                 model.getElements().add(flinkTaskmanager);
                 Container flinkJobmanagerContainer = ContainerService.create("jobmanager", containerType,
-                        flinkJobmanager, null);
+                        flinkJobmanager);
                 flinkJobmanagerContainer
                         .setPorts(ContainerService.createPorts(new String[] { "published", "8081", "target", "8081" }));
                 flinkJobmanagerContainer.getProperties()
@@ -99,10 +99,10 @@ public class AnalyticsService {
                 flinkJobmanagerContainer.getProperties()
                         .add(ModelService.createKeyValuesArray("expose", new String[] { "6123" }));
                 String analyticsVolume = downloadFlinkFatJar(outputFolder);
-                flinkJobmanagerContainer.setVolumes(
-                        VolumesService.create(new String[] { analyticsVolume }, null, null, clusterTypeTech));
+                flinkJobmanagerContainer
+                        .setVolumes(VolumesService.create(new String[] { analyticsVolume }, null, null));
                 Container flinkTaskmanagerContainer = ContainerService.create("taskmanager", containerType,
-                        flinkTaskmanager, null);
+                        flinkTaskmanager);
                 flinkTaskmanagerContainer.getDepends_on()
                         .add(ContainerService.createDependsOn(flinkJobmanagerContainer));
                 flinkTaskmanagerContainer.getProperties()
@@ -113,7 +113,7 @@ public class AnalyticsService {
                 Software authAll = SoftwareService.create("authAll",
                         properties.getProperty(PropertiesService.ANALYTICS_AUTHALL_IMAGE));
                 model.getElements().add(authAll);
-                Container authAllContainer = ContainerService.create("authAll", containerType, authAll, null);
+                Container authAllContainer = ContainerService.create("authAll", containerType, authAll);
 
                 if (properties.get(PropertiesService.ANALYTICS_DEPLOYMENT_CONTAINED).equals("false")) {
                     // separate deployment scripts for analytics get generated. the analytics
@@ -230,7 +230,7 @@ public class AnalyticsService {
                 .createEnvironment(SoftwareService.getEnvironmentFromProperties(properties, "evolution.db")));
         final String evolutionMongoContainerName = properties.getProperty(PropertiesService.EVOLUTION_DB_CONTAINERNAME);
         Container evolutionMongoContainer = ContainerService.create(evolutionMongoContainerName, containerType,
-                evolutionMongo, null);
+                evolutionMongo);
         // evolution-java
         final String evolutionJavaContainerName = properties
                 .getProperty(PropertiesService.EVOLUTION_JAVA_CONTAINERNAME);
@@ -240,7 +240,7 @@ public class AnalyticsService {
                 .createEnvironment(SoftwareService.getEnvironmentFromProperties(properties, "evolution.java")));
         model.getElements().add(evolutionJava);
         Container evolutionJavaContainer = ContainerService.create(evolutionJavaContainerName, containerType,
-                evolutionJava, null);
+                evolutionJava);
         evolutionJavaContainer.getDepends_on()
                 .addAll(ContainerService.createDependencies(new Container[] { evolutionMongoContainer,
                         ModelService.getContainer(model, properties.getProperty(PropertiesService.API_CONTAINERNAME)),
@@ -256,7 +256,7 @@ public class AnalyticsService {
                 .createEnvironment(SoftwareService.getEnvironmentFromProperties(properties, "evolution.backend")));
         model.getElements().add(evolutionBackend);
         Container evolutionBackendContainer = ContainerService.create(evolutionBackendContainerName, containerType,
-                evolutionBackend, null);
+                evolutionBackend);
         evolutionBackendContainer
                 .setPorts(ContainerService.createPorts(new String[] { "target", "3000", "published", "3000" }));
         evolutionBackendContainer.getDepends_on()

--- a/de.atb.typhondl.xtext/src/de/atb/typhondl/xtext/formatting2/TyphonDLFormatter.xtend
+++ b/de.atb.typhondl.xtext/src/de/atb/typhondl/xtext/formatting2/TyphonDLFormatter.xtend
@@ -51,6 +51,7 @@ import de.atb.typhondl.xtext.typhonDL.Environment
 import de.atb.typhondl.xtext.typhonDL.Replication
 import de.atb.typhondl.xtext.typhonDL.Volumes
 import de.atb.typhondl.xtext.typhonDL.Volume_Properties
+import de.atb.typhondl.xtext.typhonDL.Volume_Toplevel
 
 class TyphonDLFormatter extends AbstractFormatter2 {
 
@@ -225,7 +226,16 @@ class TyphonDLFormatter extends AbstractFormatter2 {
 		for (container : app.containers) {
 			container.format
 		}
+		app.volumes.format
 	}
+    
+    def dispatch void format(Volume_Toplevel volume, extension IFormattableDocument document) {
+        interior(
+            volume.regionFor.keyword('{').append[newLine],
+            volume.regionFor.keyword('}').prepend[newLine].append[newLine],
+            [indent]
+        )
+    }
 
 	def dispatch void format(Container container, extension IFormattableDocument document) {
 		interior(


### PR DESCRIPTION
Closes #66 
This update adds default named volumes to each database container using the correct target paths:
```
mariadb.volumeTarget = /var/lib/mysql
mongo.volumeTarget = /data/db
neo4j.volumeTarget = /data
cassandra.volumeTarget = /var/lib/cassandra
```