### PR TITLE
add NLAE light (development edition)

### DIFF
--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/creationWizard/CreationMainPage.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/creationWizard/CreationMainPage.java
@@ -152,11 +152,32 @@ public class CreationMainPage extends MyWizardPage {
         Button nlae = new Button(mainGroup, SWT.CHECK);
         nlae.setText("Use Typhon NLAE (needs Docker Swarm)");
         nlae.setSelection(useNLAE);
+
+        Button nlaeDev = new Button(mainGroup, SWT.CHECK);
+        nlaeDev.setText("Add NLAE-lite (only for development)");
+        nlaeDev.setSelection(Boolean.parseBoolean(properties.getProperty(PropertiesService.POLYSTORE_USENLAEDEV)));
+
         nlae.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
                 useNLAE = nlae.getSelection();
                 properties.setProperty(PropertiesService.POLYSTORE_USENLAE, Boolean.toString(useNLAE));
+                if (useNLAE) {
+                    nlaeDev.setSelection(false);
+                    properties.setProperty(PropertiesService.POLYSTORE_USENLAEDEV, "false");
+                }
+            }
+        });
+        nlaeDev.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                boolean selected = nlaeDev.getSelection();
+                properties.setProperty(PropertiesService.POLYSTORE_USENLAEDEV, Boolean.toString(selected));
+                if (selected) {
+                    nlae.setSelection(false);
+                    useNLAE = false;
+                    properties.setProperty(PropertiesService.POLYSTORE_USENLAE, "false");
+                }
             }
         });
 

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/PropertiesService.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/PropertiesService.java
@@ -6,6 +6,7 @@ public class PropertiesService {
     public static final String POLYSTORE_INAPPLICATION = "polystore.inApplication";
     public static final String POLYSTORE_USEEVOLUTION = "polystore.useEvolution";
     public static final String POLYSTORE_USENLAE = "polystore.useNLAE";
+    public static final String POLYSTORE_USENLAEDEV = "polystore.useNLAEDev";
     public static final String POLYSTORE_KUBECONFIG = "polystore.kubeconfig";
     public static final String API_NAME = "api.name";
     public static final String API_HOST = "api.host";
@@ -117,6 +118,8 @@ public class PropertiesService {
     public static final String NLAE_TASKMANAGER_SLOTS = "nlae.taskmanager.numberOfTaskSlots";
     public static final String NLAE_PARALLELISM = "nlae.flink.parallelism.default";
     public static final String NLAE_SHAREDVOLUME = "nlae.sharedvolume";
+    public static final String NLAEDEV_IMAGE = "nlaedev.image";
+    public static final String NLAEDEV_PUBLISHEDPORT = "nlaedev.publishedport";
     public static final String MARIADB_PORT = "mariadb.port";
     public static final String MYSQL_PORT = "mysql.port";
     public static final String MONGO_PORT = "mongo.port";

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/polystore.properties
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/polystore.properties
@@ -21,6 +21,7 @@ polystore.useAnalytics = false
 polystore.inApplication = default
 polystore.useEvolution = false
 polystore.useNLAE = false
+polystore.useNLAEDev = false
 polystore.kubeconfig =
 
 api.name = polystore_api
@@ -137,6 +138,8 @@ nlae.taskmanager.heapsize = 16024m
 nlae.taskmanager.numberOfTaskSlots = 8
 nlae.flink.parallelism.default = 16
 nlae.sharedvolume = /path/to/models
+nlaedev.image = ehudev/nlae-rest-api-sim:latest
+nlaedev.publishedport = 8081
 
 mariadb.port = 3306
 mysql.port = 3306


### PR DESCRIPTION
Adds the possibility to add a NLAE light version to the deployment script by selecting it on the first wizard page. Adds a rest-api (exposing port 8081) and an elasticsearch container. The api tries to find the NLAE component at `localhost:8081`

closes #68 