### PR TITLE
Analytics update

### DIFF
--- a/de.atb.typhondl.acceleo/src/de/atb/typhondl/acceleo/files/generateKubernetesDeployment.mtl
+++ b/de.atb.typhondl.acceleo/src/de/atb/typhondl/acceleo/files/generateKubernetesDeployment.mtl
@@ -27,6 +27,8 @@ sleep 1
 kubectl apply -n typhon -f kafka/strimzi-0.17.0/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml $kubeconfig
 sleep 2
 kubectl create -n typhon -f kafka/typhon-cluster.yml $kubeconfig
+sleep 1
+kubectl create -n typhon -f auth-all-deployment.yaml $kubeconfig
 echo "Waiting for Typhon Kafka K8s deployment to complete ..."
 kubectl wait kafka/typhon-cluster --for=condition=Ready --timeout=300s -n typhon $kubeconfig
 echo "Typhon Kafka K8s deployment completed."
@@ -98,6 +100,8 @@ sleep 1
 kubectl apply -n typhon -f analyticsKubernetes/kafka/strimzi-0.17.0/install/cluster-operator/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml $kubeconfig
 sleep 2
 kubectl create -n typhon -f analyticsKubernetes/kafka/typhon-cluster.yml $kubeconfig
+sleep 1
+kubectl create -n typhon -f auth-all-deployment.yaml $kubeconfig
 echo "Waiting for Typhon Kafka K8s deployment to complete ..."
 kubectl wait kafka/typhon-cluster --for=condition=Ready --timeout=300s -n typhon $kubeconfig
 echo "Typhon Kafka K8s deployment completed."

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/PropertiesService.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/PropertiesService.java
@@ -89,6 +89,7 @@ public class PropertiesService {
     public static final String ANALYTICS_KAFKA_PORT = "analytics.kafka.port";
     public static final String ANALYTICS_KAFKA_STORAGECLAIM = "analytics.kafka.storageclaim";
     public static final String ANALYTICS_ZOOKEEPER_STORAGECLAIM = "analytics.zookeeper.storageclaim";
+    public static final String ANALYTICS_FLINK_IMAGE = "analytics.flink.image";
     public static final String ANALYTICS_FLINK_JOBMANAGER_HEAP_SIZE = "analytics.flink.jobmanager.heap.size";
     public static final String ANALYTICS_FLINK_TASKMANAGER_MEMORY_PROCESS_SIZE = "analytics.flink.taskmanager.memory.process.size";
     public static final String ANALYTICS_LOGGING_ROOTLOGGER = "analytics.logging.rootlogger";

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/polystore.properties
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/properties/polystore.properties
@@ -84,6 +84,7 @@ analytics.kafka.replicas = 1
 analytics.kafka.port = 29092
 analytics.kafka.storageclaim = 100Gi
 analytics.zookeeper.storageclaim = 100Gi
+analytics.flink.image = universityofyork/typhon-analytics:latest
 analytics.flink.jobmanager.heap.size = 1024m
 analytics.flink.taskmanager.memory.process.size = 1024m
 analytics.logging.rootlogger = INFO, file

--- a/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/scriptGeneration/AnalyticsService.java
+++ b/de.atb.typhondl.xtext.ui/src/de/atb/typhondl/xtext/ui/scriptGeneration/AnalyticsService.java
@@ -72,13 +72,11 @@ public class AnalyticsService {
                             "target", properties.getProperty(PropertiesService.ANALYTICS_KAFKA_PORT) }));
                 }
                 // flink
-                Software flinkJobmanager = SoftwareService.create("FlinkJobmanager",
-                        "universityofyork/typhon-analytics");
+                Software flinkJobmanager = SoftwareService.create("FlinkJobmanager", getFlinkImage(properties));
                 flinkJobmanager.setEnvironment(
                         SoftwareService.createEnvironment(new String[] { "JOB_MANAGER_RPC_ADDRESS", "jobmanager" }));
                 model.getElements().add(flinkJobmanager);
-                Software flinkTaskmanager = SoftwareService.create("FlinkTaskmanager",
-                        "universityofyork/typhon-analytics");
+                Software flinkTaskmanager = SoftwareService.create("FlinkTaskmanager", getFlinkImage(properties));
                 flinkTaskmanager.setEnvironment(
                         SoftwareService.createEnvironment(new String[] { "JOB_MANAGER_RPC_ADDRESS", "jobmanager" }));
                 model.getElements().add(flinkTaskmanager);
@@ -286,6 +284,11 @@ public class AnalyticsService {
         list.add("\"true\"");
 
         return list.toArray(new String[0]);
+    }
+
+    public static String getFlinkImage(Properties properties) {
+        String image = properties.getProperty(PropertiesService.ANALYTICS_FLINK_IMAGE);
+        return image == null ? "universityofyork/typhon-analytics:latest" : image;
     }
 
 }


### PR DESCRIPTION
Updates the analytics component using a custom [flink image](https://hub.docker.com/r/universityofyork/typhon-analytics) and adds auth-all service to the kubernetes deployment.
Please regenerate your deployment scripts if you are using the analytics component. The DL model does not have to be changed.

(will be merged after the [analyticsKubernetes.zip](http://typhon.clmsuk.com/static/) is updated)